### PR TITLE
Added functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cd to an Android project, start vim and you're done. I use NERDTree so I'm usual
 
 The script will recognize this is an Android project by checking AndroidManifest.xml and will get the target from project.properties, then it will prepend the jar path to CLASSPATH and the [Android API](http://developer.android.com/reference/android/widget/package-summary.html) will be available to omnifunc completion.
 
-
+Setting the variable `g:add_libs_to_classpath` will add any extra jar files inside the libs/ directory (in project root) to the classpath.
 # License
 
 As usual (will fill in when I'll manage to understand license-world).

--- a/java.vim
+++ b/java.vim
@@ -5,11 +5,26 @@ if glob('AndroidManifest.xml') =~ ''
         "let s:androidTargetPlatform = system('grep target= project.properties | cut -d \= -f 2')
         vimgrep /target=/j project.properties
         let s:androidTargetPlatform = split(getqflist()[0].text, '=')[1] 
+        let s:tmp_target = split(s:androidTargetPlatform, ':')
+
+        if len(s:tmp_target) > 1
+            let s:androidTargetPlatform = 'android-' . s:tmp_target[len(s:tmp_target)-1]
+        endif
         let s:targetAndroidJar = s:androidSdkPath . '/platforms/' . s:androidTargetPlatform . '/android.jar'
         if $CLASSPATH =~ ''
             let $CLASSPATH = s:targetAndroidJar . ':' . $CLASSPATH
         else
             let $CLASSPATH = s:targetAndroidJar
         endif
-    end
+        if exists('g:add_libs_to_classpath')
+            if isdirectory('libs')
+                let s:extra_libs = split(globpath('libs', '*.jar'), '\n')
+                let c = 0
+                while c < len(s:extra_libs)
+                    let $CLASSPATH = fnamemodify(s:extra_libs[c], ':p') . ':' . $CLASSPATH
+                    let c += 1
+                endwhile
+            endif
+        endif
+    endif
 endif


### PR DESCRIPTION
Added a check when getting the target for if it's a add-on target name (e.g. Google APIs:Google Inc.:10) and resolving it to the base android target name.

Also added a global variable g:add_libs_to_classpath which when
set in .vimrc has the script add all .jar's inside {project root}/libs/
to classpath.
